### PR TITLE
feat(db): store full raw agent output in SQLite

### DIFF
--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -108,6 +108,8 @@ struct AgentRunReport {
     status: String,
     cost_usd: f64,
     turns: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw_output: Option<String>,
 }
 
 impl RunReport {
@@ -128,6 +130,7 @@ impl RunReport {
                     status: ar.status.clone(),
                     cost_usd: ar.cost_usd,
                     turns: ar.turns,
+                    raw_output: ar.raw_output.clone(),
                 })
                 .collect(),
         }
@@ -171,6 +174,7 @@ mod tests {
                 finished_at: Some("2026-03-12T10:03:15".to_string()),
                 output_summary: None,
                 error_message: None,
+                raw_output: None,
             },
             AgentRun {
                 id: 2,
@@ -184,6 +188,7 @@ mod tests {
                 finished_at: Some("2026-03-12T10:04:57".to_string()),
                 output_summary: None,
                 error_message: None,
+                raw_output: None,
             },
         ]
     }
@@ -279,6 +284,7 @@ mod tests {
             finished_at: Some("2026-03-12T10:30:00".to_string()),
             output_summary: None,
             error_message: Some("budget".to_string()),
+            raw_output: None,
         }];
         let report = RunReport::from_run(&run, &agents);
         assert_eq!(report.id, "test0001");

--- a/src/db/agent_runs.rs
+++ b/src/db/agent_runs.rs
@@ -6,8 +6,8 @@ use super::{AgentRun, ReviewFinding};
 pub fn insert_agent_run(conn: &Connection, agent_run: &AgentRun) -> Result<i64> {
     conn.execute(
         "INSERT INTO agent_runs (run_id, agent, cycle, status, cost_usd, turns, \
-         started_at, finished_at, output_summary, error_message) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+         started_at, finished_at, output_summary, error_message, raw_output) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         params![
             agent_run.run_id,
             agent_run.agent,
@@ -19,6 +19,7 @@ pub fn insert_agent_run(conn: &Connection, agent_run: &AgentRun) -> Result<i64> 
             agent_run.finished_at,
             agent_run.output_summary,
             agent_run.error_message,
+            agent_run.raw_output,
         ],
     )
     .context("inserting agent run")?;
@@ -29,7 +30,7 @@ pub fn get_agent_runs_for_run(conn: &Connection, run_id: &str) -> Result<Vec<Age
     let mut stmt = conn
         .prepare(
             "SELECT id, run_id, agent, cycle, status, cost_usd, turns, \
-             started_at, finished_at, output_summary, error_message \
+             started_at, finished_at, output_summary, error_message, raw_output \
              FROM agent_runs WHERE run_id = ?1 ORDER BY id",
         )
         .context("preparing get_agent_runs_for_run")?;
@@ -48,6 +49,7 @@ pub fn get_agent_runs_for_run(conn: &Connection, run_id: &str) -> Result<Vec<Age
                 finished_at: row.get(8)?,
                 output_summary: row.get(9)?,
                 error_message: row.get(10)?,
+                raw_output: row.get(11)?,
             })
         })
         .context("querying agent runs")?;
@@ -55,6 +57,7 @@ pub fn get_agent_runs_for_run(conn: &Connection, run_id: &str) -> Result<Vec<Age
     rows.collect::<std::result::Result<Vec<_>, _>>().context("collecting agent runs")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn finish_agent_run(
     conn: &Connection,
     id: i64,
@@ -63,12 +66,13 @@ pub fn finish_agent_run(
     turns: u32,
     output_summary: Option<&str>,
     error_message: Option<&str>,
+    raw_output: Option<&str>,
 ) -> Result<()> {
     conn.execute(
         "UPDATE agent_runs SET status = ?1, cost_usd = ?2, turns = ?3, \
-         finished_at = datetime('now'), output_summary = ?4, error_message = ?5 \
-         WHERE id = ?6",
-        params![status, cost_usd, turns, output_summary, error_message, id],
+         finished_at = datetime('now'), output_summary = ?4, error_message = ?5, \
+         raw_output = ?6 WHERE id = ?7",
+        params![status, cost_usd, turns, output_summary, error_message, raw_output, id],
     )
     .context("finishing agent run")?;
     Ok(())
@@ -190,6 +194,7 @@ mod tests {
             finished_at: None,
             output_summary: None,
             error_message: None,
+            raw_output: None,
         }
     }
 
@@ -213,7 +218,7 @@ mod tests {
         insert_test_run(&conn, "run1");
         let id = insert_agent_run(&conn, &sample_agent_run("run1", "reviewer")).unwrap();
 
-        finish_agent_run(&conn, id, "complete", 1.50, 8, Some("all good"), None).unwrap();
+        finish_agent_run(&conn, id, "complete", 1.50, 8, Some("all good"), None, None).unwrap();
 
         let runs = get_agent_runs_for_run(&conn, "run1").unwrap();
         assert_eq!(runs[0].status, "complete");
@@ -330,6 +335,19 @@ mod tests {
         let unresolved = get_unresolved_findings(&conn, "run1").unwrap();
         assert_eq!(unresolved.len(), 1);
         assert_eq!(unresolved[0].message, "bad");
+    }
+
+    #[test]
+    fn raw_output_round_trips() {
+        let conn = test_db();
+        insert_test_run(&conn, "run1");
+        let id = insert_agent_run(&conn, &sample_agent_run("run1", "implementer")).unwrap();
+
+        let raw = r#"{"batches":[{"batch":1,"issues":[]}]}"#;
+        finish_agent_run(&conn, id, "complete", 0.5, 3, Some("ok"), None, Some(raw)).unwrap();
+
+        let runs = get_agent_runs_for_run(&conn, "run1").unwrap();
+        assert_eq!(runs[0].raw_output.as_deref(), Some(raw));
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -57,6 +57,7 @@ CREATE INDEX idx_findings_severity ON review_findings(severity);",
         ),
         M::up("ALTER TABLE runs ADD COLUMN complexity TEXT NOT NULL DEFAULT 'full';"),
         M::up("ALTER TABLE runs ADD COLUMN issue_source TEXT NOT NULL DEFAULT 'github';"),
+        M::up("ALTER TABLE agent_runs ADD COLUMN raw_output TEXT;"),
     ])
 });
 
@@ -157,6 +158,7 @@ pub struct AgentRun {
     pub finished_at: Option<String>,
     pub output_summary: Option<String>,
     pub error_message: Option<String>,
+    pub raw_output: Option<String>,
 }
 
 /// A review finding from the reviewer agent.

--- a/src/pipeline/executor.rs
+++ b/src/pipeline/executor.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use rusqlite::Connection;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     agents::{
@@ -127,9 +127,10 @@ impl<R: CommandRunner + 'static> PipelineExecutor<R> {
 
         match invoke_agent(self.runner.as_ref(), &invocation).await {
             Ok(result) => {
+                debug!(output = %result.output, "raw planner output");
                 let parsed = parse_planner_output(&result.output);
                 if parsed.is_none() {
-                    warn!("planner returned unparseable output, falling back to single batch");
+                    warn!(output = %result.output, "planner returned unparseable output, falling back to single batch");
                 }
                 parsed
             }
@@ -429,6 +430,7 @@ impl<R: CommandRunner + 'static> PipelineExecutor<R> {
                     0,
                     None,
                     Some(&format!("{e:#}")),
+                    None,
                 )?;
             }
         }
@@ -449,6 +451,7 @@ impl<R: CommandRunner + 'static> PipelineExecutor<R> {
             finished_at: None,
             output_summary: None,
             error_message: None,
+            raw_output: None,
         };
         let conn = self.db.lock().await;
         db::agent_runs::insert_agent_run(&conn, &agent_run)
@@ -469,6 +472,7 @@ impl<R: CommandRunner + 'static> PipelineExecutor<R> {
             agent_result.turns,
             Some(&truncate(&agent_result.output, 500)),
             None,
+            Some(&agent_result.output),
         )?;
 
         let new_cost = db::runs::increment_run_cost(&conn, run_id, agent_result.cost_usd)?;

--- a/tests/db_tests.rs
+++ b/tests/db_tests.rs
@@ -85,6 +85,7 @@ fn agent_run_with_findings() {
             finished_at: None,
             output_summary: None,
             error_message: None,
+            raw_output: None,
         },
     )
     .unwrap();

--- a/tests/pipeline_tests.rs
+++ b/tests/pipeline_tests.rs
@@ -162,6 +162,7 @@ fn run_and_agent_run_cost_aggregation() {
                 finished_at: Some("2026-03-12T10:02:00".to_string()),
                 output_summary: None,
                 error_message: None,
+                raw_output: None,
             },
         )
         .unwrap();


### PR DESCRIPTION
## Summary
- Adds `raw_output TEXT` column to `agent_runs` table (migration 4) so complete agent responses are persisted alongside the truncated `output_summary`
- Passes full output through `record_agent_success` for implementer, reviewer, fixer, and merger agents
- Logs raw planner output at debug level (and in the warn message on parse failure) since the planner bypasses `run_agent()` and has no DB record
- Exposes `raw_output` in `oven report --json` output (skipped when null)

## Test plan
- [x] New `raw_output_round_trips` test verifies insert/finish/get cycle
- [x] All 296 existing tests pass
- [x] `cargo clippy` and `cargo +nightly fmt` clean
- [ ] Manual: run `oven on <issue>`, then `sqlite3 .oven/oven.db "SELECT agent, length(raw_output) FROM agent_runs"` to confirm outputs are stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)