### PR TITLE
fix(process): add --verbose flag to claude CLI invocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ Migrations via rusqlite_migration (user_version based, no migration table). Test
 ## Process management
 - `tokio::process::Command` with `kill_on_drop(true)` for all subprocesses.
 - Graceful shutdown: `CancellationToken` from tokio-util combined with `tokio::signal::ctrl_c()`.
-- Agent invocation: `claude -p --output-format stream-json --allowedTools <TOOLS>`.
+- Agent invocation: `claude -p --verbose --output-format stream-json --allowedTools <TOOLS>`.
 - Detached mode: spawn new process with `std::process::Command` (not fork). Write PID to `.oven/oven.pid`.
 - Always `wait()` on child processes to prevent zombies.
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -61,7 +61,8 @@ impl CommandRunner for RealCommandRunner {
         let tools_arg = allowed_tools.join(",");
 
         let mut cmd = Command::new("claude");
-        cmd.args(["-p", "--output-format", "stream-json"]).args(["--allowedTools", &tools_arg]);
+        cmd.args(["-p", "--verbose", "--output-format", "stream-json"])
+            .args(["--allowedTools", &tools_arg]);
 
         if let Some(turns) = max_turns {
             cmd.args(["--max-turns", &turns.to_string()]);


### PR DESCRIPTION
## Summary
- `claude -p --output-format stream-json` requires `--verbose` to produce stream events. Without it, the CLI errors silently and agents receive empty output.
- This caused the planner to always return unparseable output (empty string), falling back to single-batch mode. All other agents were also affected -- they'd produce empty output from the stream parser.
- Adds `--verbose` to the single `run_claude` codepath in `RealCommandRunner`, which all 5 agents use.

## Test plan
- [x] `cargo +nightly fmt` -- clean
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo nextest run` -- 296/296 pass
- [ ] Manual: run `debug-planner.sh` (in repo root) to verify stream-json now produces assistant text blocks
- [ ] Manual: `oven on 3` to verify full pipeline gets planner output

🤖 Generated with [Claude Code](https://claude.com/claude-code)