### PR TITLE
release: v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oven-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oven-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI that runs Claude Code agent pipelines against GitHub issues"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ oven ticket close 1
 
 Tickets are markdown files in `.oven/issues/`. Oven picks them up the same way it picks up GitHub issues. PRs still go to GitHub.
 
+## Skills
+
+`oven prep` scaffolds Claude Code skills into `.claude/skills/` for use alongside your normal development workflow.
+
+**`/cook`** -- Interactive issue design. Researches your codebase, asks targeted clarifying questions, and produces an implementation-ready issue that an agent with zero prior context can pick up. Creates the issue via `gh issue create` or `oven ticket create` depending on your `issue_source` config.
+
+**`/refine`** -- Codebase audit across six dimensions: security, error handling, patterns, test gaps, data issues, and dependencies. Runs static analysis tools, performs manual code review, and produces a prioritized findings report. Offers to generate issues from critical and high findings.
+
 ---
 
 Built with Rust.


### PR DESCRIPTION
## Summary

- Bump version to 0.2.0
- Add `/cook` and `/refine` skills to README

### Changes since v0.1.0

**Features:**
- Planner-driven parallelism with batch sequencing (#10)
- Merge conflict resolution via rebase + force push
- In-flight issue context for conflict-aware batching

**Fixes:**
- Merger uses `base_branch` instead of hardcoded `main`
- Don't mark PR ready when `auto_merge` is false
- Stop batches on first failure
- Git identity config in the GitHub Action

**Chores:**
- Automated release workflow
- Dead code removal (OvenError enum, thiserror dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)