### PR TITLE
chore: release v0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oven-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oven-cli"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI that runs Claude Code agent pipelines against GitHub issues"


### PR DESCRIPTION
## Summary

- Bump version to 0.9.5

### Changes since v0.9.4

- fix: invert merge retry logic to deny-list permanent errors (#52)